### PR TITLE
Fix code scanning alert no. 5: Information exposure through an exception

### DIFF
--- a/zoo-python-fastapi/app/routes/schema.py
+++ b/zoo-python-fastapi/app/routes/schema.py
@@ -40,7 +40,7 @@ async def route_list():
     """List of GQL schema versions for download, returns array of versions as strings"""
     result = await schema_list()
     if result.get("status") == "ERROR":
-        return JSONResponse(status_code=403, content={"status": "ERROR", "error": "An internal error has occurred."})
+        return JSONResponse(status_code=403, content=result)
 
     return JSONResponse(status_code=200, content=result)
 

--- a/zoo-python-fastapi/app/routes/schema.py
+++ b/zoo-python-fastapi/app/routes/schema.py
@@ -39,8 +39,8 @@ async def route_generate():
 async def route_list():
     """List of GQL schema versions for download, returns array of versions as strings"""
     result = await schema_list()
-    if "ERROR" in result.values():
-        return JSONResponse(status_code=403, content=result)
+    if result.get("status") == "ERROR":
+        return JSONResponse(status_code=403, content={"status": "ERROR", "error": "An internal error has occurred."})
 
     return JSONResponse(status_code=200, content=result)
 

--- a/zoo-python-fastapi/app/services/schema/schema_generate.py
+++ b/zoo-python-fastapi/app/services/schema/schema_generate.py
@@ -25,10 +25,9 @@ async def schema_generate():
     try:
         await store_schema_file(version, contents)
     except Exception as e:
-        message = f"Failed to store the schema file: [{str(e)}]."
-        logger.error(message)
+        logger.error(f"Failed to store the schema file: [{str(e)}].")
         return {"status": "ERROR",
-                "error": message}
+                "error": "Failed to store the schema file, investigate the logs."}
 
     return {"status": "OK", "result": version}
 

--- a/zoo-python-fastapi/app/services/schema/schema_generate.py
+++ b/zoo-python-fastapi/app/services/schema/schema_generate.py
@@ -27,7 +27,7 @@ async def schema_generate():
     except Exception as e:
         logger.error(f"Failed to store the schema file: [{str(e)}].")
         return {"status": "ERROR",
-                "error": "Failed to store the schema file, investigate the logs."}
+                "error": "Failed to store the schema file, examine the logs."}
 
     return {"status": "OK", "result": version}
 

--- a/zoo-python-fastapi/app/services/schema/schema_list.py
+++ b/zoo-python-fastapi/app/services/schema/schema_list.py
@@ -11,9 +11,8 @@ async def schema_list():
         versions = [f.replace('schema_', '').replace('.graphql', '')
                     for f in os.listdir(Config.SCHEMA_DIR) if f.endswith('.graphql')]
     except Exception as e:
-        message = f"Failed to list the versions [{str(e)}]"
-        logger.error(message)
-        return {"status": "ERROR", "error": message}
+        logger.error(f"Failed to list the versions [{str(e)}]")
+        return {"status": "ERROR", "error": "An internal error has occurred."}
 
     logger.info("Schemas was listed.")
     return {"status": "OK", "result": versions}

--- a/zoo-python-fastapi/app/services/schema/schema_list.py
+++ b/zoo-python-fastapi/app/services/schema/schema_list.py
@@ -12,7 +12,7 @@ async def schema_list():
                     for f in os.listdir(Config.SCHEMA_DIR) if f.endswith('.graphql')]
     except Exception as e:
         logger.error(f"Failed to list the versions: [{str(e)}]")
-        return {"status": "ERROR", "error": "Failed to list the versions. Examine the logs."}
+        return {"status": "ERROR", "error": "Failed to list the versions, examine the logs."}
 
     logger.info("Schemas was listed.")
     return {"status": "OK", "result": versions}

--- a/zoo-python-fastapi/app/services/schema/schema_list.py
+++ b/zoo-python-fastapi/app/services/schema/schema_list.py
@@ -11,8 +11,8 @@ async def schema_list():
         versions = [f.replace('schema_', '').replace('.graphql', '')
                     for f in os.listdir(Config.SCHEMA_DIR) if f.endswith('.graphql')]
     except Exception as e:
-        logger.error(f"Failed to list the versions [{str(e)}]")
-        return {"status": "ERROR", "error": "An internal error has occurred."}
+        logger.error(f"Failed to list the versions: [{str(e)}]")
+        return {"status": "ERROR", "error": "Failed to list the versions. Examine the logs."}
 
     logger.info("Schemas was listed.")
     return {"status": "OK", "result": versions}

--- a/zoo-python-fastapi/starter.ps1
+++ b/zoo-python-fastapi/starter.ps1
@@ -1,4 +1,0 @@
-docker kill fastapi
-docker rm fastapi
-docker build -t fastapi .
-docker run -e DB_USERNAME=root -e DB_PASSWORD=007 -e DB_HOSTNAME=mysql-master.intel.r7g.org -e DB_DATABASE=laravel_test -p 8001:8001 --name fastapi fastapi


### PR DESCRIPTION
Fixes [https://github.com/intelligent002/micro-service-zoo/security/code-scanning/5](https://github.com/intelligent002/micro-service-zoo/security/code-scanning/5)

To fix the problem, we need to ensure that detailed exception messages are not exposed to the end user. Instead, we should return a generic error message while logging the detailed exception message on the server. This can be achieved by modifying the `schema_list` function to return a generic error message and updating the `route_list` function to handle this appropriately.

1. Modify the `schema_list` function in `zoo-python-fastapi/app/services/schema/schema_list.py` to return a generic error message.
2. Update the `route_list` function in `zoo-python-fastapi/app/routes/schema.py` to handle the generic error message and return an appropriate HTTP response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
